### PR TITLE
add a descriptive __repr__

### DIFF
--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -207,7 +207,11 @@ class Storm(object):
         return output
 
     def __repr__(self):
-        return "None"
+        return '<{}.{} "{}" at {}>'.format(
+	    self.__class__.__module__,
+	    self.__class__.__name__,
+	    self.__dict__.get('name', 'name not given'),
+	    hex(id(sample_gc_storm)))
 
     # ==========================================================================
     # Read Routines


### PR DESCRIPTION
Adds a repr which displays the module.class, storm name, and adress, e.g.:
```<clawpack.geoclaw.surge.storm.Storm "ncep_reanal_1979_1989_989" at 0x7f2f14fa4898>```